### PR TITLE
removes specific rich-text configs

### DIFF
--- a/lib/area.js
+++ b/lib/area.js
@@ -1,117 +1,9 @@
-const tiptapStyles = {
-  all: [
-    {
-      tag: 'p',
-      label: 'Paragraph (P)'
-    },
-    {
-      tag: 'h1',
-      label: 'Heading 1 (H1)'
-    },
-    {
-      tag: 'h2',
-      label: 'Heading 2 (H2)'
-    },
-    {
-      tag: 'h3',
-      label: 'Heading 3 (H3)'
-    },
-    {
-      tag: 'h4',
-      label: 'Heading 4 (H4)'
-    },
-    {
-      tag: 'span',
-      label: 'Small',
-      class: 'small'
-    },
-    {
-      tag: 'span',
-      label: 'Lead',
-      class: 'lead'
-    },
-    {
-      tag: 'span',
-      label: 'Highlight: Primary',
-      class: 'highlight-primary'
-    },
-    {
-      tag: 'span',
-      label: 'Highlight: Secondary',
-      class: 'highlight-secondary'
-    },
-    {
-      tag: 'span',
-      label: 'Highlight: Tertiary',
-      class: 'highlight-tertiary'
-    },
-    {
-      tag: 'span',
-      label: 'Highlight: Black',
-      class: 'highlight-black'
-    },
-    {
-      tag: 'span',
-      label: 'Highlight: White',
-      class: 'highlight-white'
-    }
-  ],
-  simple: {}
-};
-
-const tiptapTools = {
-  all: [
-    'styles',
-    '|',
-    'bold',
-    'italic',
-    'strike',
-    // 'superscript',
-    // 'subscript',
-    '|',
-    'link',
-    'anchor',
-    'horizontalRule',
-    '|',
-    'bulletList',
-    'orderedList',
-    // 'blockquote',
-    '|',
-    'alignLeft',
-    'alignCenter',
-    'alignRight',
-    'alignJustify'
-    // '|',
-    // 'table',
-    // '|',
-    // 'image',
-    // 'codeBlock',
-    // '|',
-    // 'undo',
-    // 'redo'
-  ],
-  simple: [
-    'styles',
-    '|',
-    'bold',
-    'italic',
-    '|',
-    'link',
-    '|',
-    'bulletList',
-    'orderedList'
-  ]
-};
-
 const apostropheWidgets = {
   '@apostrophecms/image': {
     className: 'img-fluid'
   },
   '@apostrophecms/video': {},
-  '@apostrophecms/rich-text': {
-    toolbar: tiptapTools.all,
-    styles: tiptapStyles.all
-  }
+  '@apostrophecms/rich-text': {}
 };
 
 export default {
@@ -166,10 +58,7 @@ export default {
     ...apostropheWidgets
   },
   richText: {
-    '@apostrophecms/rich-text': {
-      toolbar: tiptapTools.all,
-      styles: tiptapStyles.all
-    }
+    '@apostrophecms/rich-text': {}
   },
   fullExpandedGroup: {
     layout: {


### PR DESCRIPTION
[PRO-7646](https://linear.app/apostrophecms/issue/PRO-7646/as-an-editor-i-want-multiple-headings-in-the-rich-text-toolbar-set-up)

## Summary

Remove all rich-text specific configs to use new default.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
